### PR TITLE
Improve CLI Reddit pagination, parsing, and HTTP handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-- Go `1.21+`
+- Go `1.25+`
 
 ## Install
 
@@ -39,18 +39,24 @@ snoo-dl download wallpapers week --location ./images --resolution 1920x1080
 
 # Filter by aspect ratio
 snoo-dl download wallpapers all --aspect-ratio 16:9
+
+# Process up to 300 top posts (fetched with Reddit pagination)
+snoo-dl download wallpapers month --limit 300
 ```
 
 Flags:
 
 - `-l, --location` download directory (default `./`)
+- `--limit` max number of top posts to process (default `100`)
 - `-r, --resolution` exact resolution filter, format `WIDTHxHEIGHT` (example: `1920x1080`)
 - `-a, --aspect-ratio` ratio filter, format `W:H` (example: `16:9`)
 - `--config` optional path to config file (`$HOME/.snoodl.yaml` by default)
 
 ## Current behavior and notes
 
-- Only direct image URLs are downloaded (`.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`).
+- Top posts are fetched with pagination until `--limit` is reached or no additional pages exist.
+- Image URL extraction includes direct URLs, preview source URLs, and gallery media metadata.
+- Only image URLs with known supported formats are downloaded (`.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`).
 - Existing files are skipped.
 - Invalid filter formats return a friendly error instead of crashing.
 - Reddit API failures and download HTTP failures return clear errors.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Flags:
 ## Current behavior and notes
 
 - Top posts are fetched with pagination until `--limit` is reached or no additional pages exist.
-- Image URL extraction includes direct URLs, preview source URLs, and gallery media metadata.
+- Image URL extraction includes direct/original post URLs and gallery media metadata (preview variants are skipped).
 - Only image URLs with known supported formats are downloaded (`.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`).
 - Existing files are skipped.
 - Invalid filter formats return a friendly error instead of crashing.

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -1,6 +1,17 @@
 package cmd
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shayd3/snoo-dl/models"
+)
 
 func TestParseFiltersValid(t *testing.T) {
 	filter, err := parseFilters("1920x1080", "16:9")
@@ -47,9 +58,14 @@ func TestImageExtension(t *testing.T) {
 		t.Fatalf("expected .png, got %s", got)
 	}
 
+	got = imageExtension("https://example.com/no-ext?format=webp")
+	if got != ".webp" {
+		t.Fatalf("expected .webp from query format, got %s", got)
+	}
+
 	got = imageExtension("https://example.com/no-ext")
-	if got != ".jpg" {
-		t.Fatalf("expected .jpg fallback, got %s", got)
+	if got != "" {
+		t.Fatalf("expected empty extension for unknown format, got %s", got)
 	}
 }
 
@@ -58,5 +74,132 @@ func TestSanitizeFilename(t *testing.T) {
 	want := "Hello__r_wallpapers__4K"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestExtractCandidateImageURLs(t *testing.T) {
+	post := models.Post{
+		Data: models.PostData{
+			Url:                 "https://i.redd.it/from-url.jpg",
+			URLOverriddenByDest: "https://i.redd.it/from-overridden.png",
+			IsGallery:           true,
+			GalleryData: models.GalleryData{
+				Items: []models.GalleryItem{
+					{MediaID: "media-1"},
+				},
+			},
+			MediaMetadata: map[string]models.MediaMeta{
+				"media-1": {
+					S: struct {
+						U string `json:"u"`
+						X int    `json:"x"`
+						Y int    `json:"y"`
+					}{
+						U: "https://i.redd.it/gallery.webp",
+					},
+				},
+			},
+			Preview: models.Preview{
+				Images: []models.PreviewImage{
+					{
+						Source: models.ImageSource{
+							URL: "https://preview.redd.it/source.jpg?width=1920&amp;format=pjpg",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := extractCandidateImageURLs(post)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 candidate URLs, got %d (%v)", len(got), got)
+	}
+
+	for _, url := range got {
+		if strings.Contains(url, "&amp;") {
+			t.Fatalf("expected HTML entities to be unescaped, got %q", url)
+		}
+	}
+}
+
+func TestGetTopWallpapersPaginatesAndHonorsLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+	var serverURL string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/img/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("test-image"))
+	})
+	mux.HandleFunc("/r/test/top.json", func(w http.ResponseWriter, r *http.Request) {
+		after := r.URL.Query().Get("after")
+		limit := r.URL.Query().Get("limit")
+		if limit != "3" && limit != "1" {
+			t.Fatalf("unexpected page limit value %q", limit)
+		}
+
+		type response struct {
+			Data struct {
+				Children []models.Post `json:"children"`
+				After    string        `json:"after"`
+			} `json:"data"`
+		}
+		out := response{}
+
+		switch after {
+		case "":
+			out.Data.Children = []models.Post{
+				{Data: models.PostData{Title: "first", URLOverriddenByDest: "http://example.com/invalid"}},
+				{Data: models.PostData{Title: "second", URLOverriddenByDest: serverURL + "/img/second.jpg"}},
+			}
+			out.Data.After = "page2"
+		case "page2":
+			out.Data.Children = []models.Post{
+				{Data: models.PostData{Title: "third", URLOverriddenByDest: serverURL + "/img/third.jpg"}},
+			}
+			out.Data.After = "page3"
+		default:
+			out.Data.Children = []models.Post{
+				{Data: models.PostData{Title: "fourth", URLOverriddenByDest: serverURL + "/img/fourth.jpg"}},
+			}
+		}
+
+		_ = json.NewEncoder(w).Encode(out)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	serverURL = server.URL
+
+	originalRedditURL := redditURL
+	originalClient := httpClient
+	redditURL = server.URL + "/r"
+	httpClient = server.Client()
+	defer func() {
+		redditURL = originalRedditURL
+		httpClient = originalClient
+	}()
+
+	if err := getTopWallpapers(context.Background(), "test", "week", models.Filter{}, tmpDir, 3); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	files, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to read temp directory: %v", err)
+	}
+
+	if len(files) != 2 {
+		t.Fatalf("expected 2 downloaded files (invalid URL skipped), got %d", len(files))
+	}
+
+	_, err = os.Stat(filepath.Join(tmpDir, "second.jpg"))
+	if err != nil {
+		t.Fatalf("expected second.jpg to exist: %v", err)
+	}
+	_, err = os.Stat(filepath.Join(tmpDir, "third.jpg"))
+	if err != nil {
+		t.Fatalf("expected third.jpg to exist: %v", err)
 	}
 }

--- a/models/reddit_post.go
+++ b/models/reddit_post.go
@@ -2,17 +2,50 @@ package models
 
 // Post is a struct representing a reddit post
 type Post struct {
-	Data struct {
-		Title   string `json:"title"`
-		Url     string `json:"url"`
-		Preview struct {
-			Images []struct {
-				Source struct {
-					Height int    `json:"height"`
-					URL    string `json:"url"`
-					Width  int    `json:"width"`
-				} `json:"source"`
-			} `json:"images"`
-		} `json:"preview"`
-	} `json:"data"`
+	Kind string   `json:"kind"`
+	Data PostData `json:"data"`
+}
+
+type PostData struct {
+	ID                  string               `json:"id"`
+	Title               string               `json:"title"`
+	Url                 string               `json:"url"`
+	URLOverriddenByDest string               `json:"url_overridden_by_dest"`
+	PostHint            string               `json:"post_hint"`
+	IsGallery           bool                 `json:"is_gallery"`
+	Preview             Preview              `json:"preview"`
+	GalleryData         GalleryData          `json:"gallery_data"`
+	MediaMetadata       map[string]MediaMeta `json:"media_metadata"`
+}
+
+type Preview struct {
+	Images []PreviewImage `json:"images"`
+}
+
+type PreviewImage struct {
+	Source      ImageSource   `json:"source"`
+	Resolutions []ImageSource `json:"resolutions"`
+}
+
+type ImageSource struct {
+	Height int    `json:"height"`
+	URL    string `json:"url"`
+	Width  int    `json:"width"`
+}
+
+type GalleryData struct {
+	Items []GalleryItem `json:"items"`
+}
+
+type GalleryItem struct {
+	MediaID string `json:"media_id"`
+}
+
+type MediaMeta struct {
+	E string `json:"e"`
+	S struct {
+		U string `json:"u"`
+		X int    `json:"x"`
+		Y int    `json:"y"`
+	} `json:"s"`
 }

--- a/models/reddit_response.go
+++ b/models/reddit_response.go
@@ -2,7 +2,10 @@ package models
 
 // Response is a struct representing a response from the reddit api
 type Response struct {
-	Data struct {
-		Post []Post `json:"children"`
-	} `json:"data"`
+	Data ListingData `json:"data"`
+}
+
+type ListingData struct {
+	Post  []Post `json:"children"`
+	After string `json:"after"`
 }


### PR DESCRIPTION
## Summary
- add --limit and paginate Reddit /top.json using after until the requested count is processed
- use context-aware requests and a shared timeout HTTP client for both Reddit listing fetches and image downloads
- expand Reddit models and extraction logic to pull image candidates from direct URL fields, preview sources/resolutions, and gallery media metadata
- add tests for URL extraction and pagination/limit behavior with httptest
- update README with new --limit usage and behavior notes

## Validation
- go test ./...
- go vet ./...